### PR TITLE
fix: fehlendes bootstrap-icons-Paket ergänzen, damit die bi-Icons rendern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Alle wichtigen Änderungen und Updates des Kickbase Calculators auf einen Blick.
 
 ### 🚀 Neue Features & Verbesserungen
 - **Dunkelmodus:** Der Rechner lässt sich jetzt zwischen Hell, Dunkel und der System-Einstellung des Geräts umschalten. Der Schalter sitzt oben rechts und ist auch auf der Login-Seite erreichbar. Die Auswahl wird im Browser gespeichert.
+- **Symbole sichtbar:** Die Icons in Buttons, Hinweisen und Überschriften (Rechner, Markt, Aktualisieren, Logout, Erfolge …) werden jetzt tatsächlich angezeigt – das dafür nötige Icon-Paket hatte bisher gefehlt.
 
 ---
 

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -21,6 +21,7 @@
       "resources": {
         "files": [
           "/assets/**",
+          "/media/**",
           "/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)"
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/service-worker": "22.1.2",
         "angular-svg-icon": "19.1.1",
         "bootstrap": "5.3.8",
+        "bootstrap-icons": "1.13.1",
         "ngx-bootstrap": "22.0.0",
         "rxjs": "7.8.2",
         "tslib": "2.8.1",
@@ -3909,6 +3910,22 @@
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+      "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.18",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@angular/service-worker": "22.1.2",
     "angular-svg-icon": "19.1.1",
     "bootstrap": "5.3.8",
+    "bootstrap-icons": "1.13.1",
     "ngx-bootstrap": "22.0.0",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",

--- a/src/app/components/help/help.component.html
+++ b/src/app/components/help/help.component.html
@@ -16,7 +16,7 @@
       <a
         href="https://pascalhenze.de/kickbase-doc"
         target="_blank"
-        class="btn btn-sm btn-outline-primary"
+        class="btn btn-sm btn-outline-primary text-nowrap"
         (click)="$event.stopPropagation()"
       >
         <i class="bi bi-book me-1"></i>Doku

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,6 +16,14 @@
 
 @use 'sass:color';
 
+// Bootstrap Icons. Die Templates nutzen durchgängig <i class="bi bi-...">,
+// bislang fehlte nur das Paket dazu. Ausgeliefert wird ausschließlich woff2 –
+// das mitgelieferte .woff (180 kB) ist ein Fallback für Browser, die dieses
+// Angular-Build ohnehin nicht ausführen können.
+@use 'bootstrap-icons/font/bootstrap-icons' with (
+  $bootstrap-icons-font-src: url('bootstrap-icons/font/fonts/bootstrap-icons.woff2') format('woff2')
+);
+
 @import url('https://fonts.googleapis.com/css?family=Muli:200,300,400,700&display=swap');
 @import url('https://fonts.googleapis.com/css?family=Oswald:200,300,400,700&display=swap');
 


### PR DESCRIPTION
Wie in #24 besprochen – hier der Nachzügler für die Bootstrap Icons.

## Das Problem

Die Templates nutzen an **21 Stellen** `<i class="bi bi-…">` – Rechner-/Markt-Tab, Aktualisieren, Logout, die Überschriften in der Hilfe, die Zeilen in der Zusammenfassung, die Card-Header. Nur war `bootstrap-icons` weder in der `package.json` noch per CDN eingebunden. Alle diese Elemente haben bisher schlicht nichts gerendert.

Betroffen waren 18 verschiedene Icons: `arrow-clockwise`, `arrow-repeat`, `book`, `box-arrow-right`, `calculator`, `calendar-event`, `cone-striped`, `exclamation-triangle-fill`, `graph-down-arrow`, `graph-up-arrow`, `info-circle-fill`, `people`, `question-circle`, `shield-check`, `sliders`, `tags-fill`, `trophy`. Alle 18 existieren im Paket, es waren keine Tippfehler dabei.

## Änderungen

**1. Paket rein, ein Import.** `bootstrap-icons@1.13.1` als Dependency, eine `@use`-Zeile in `styles.scss`. Keine Template-Umbauten – die `bi bi-*`-Klassen bleiben wie sie sind, und künftige Icons funktionieren einfach.

**2. Nur woff2 ausliefern.** Das Paket bringt woff2 (134 kB) *und* ein Legacy-woff (180 kB) mit. Kein Browser, der dieses Angular-22-Build ausführen kann, braucht das woff. Über `$bootstrap-icons-font-src` fliegt es aus dem Build-Artefakt.

**3. `ngsw-config.json`: `/media/**` ergänzt.** Das ist der Punkt, den ich fast übersehen hätte. Angular legt Fonts unter `/media/` ab, und die bestehenden Globs treffen das nicht – `/assets/**` passt nicht, und `/*.(…|woff2|…)` greift nur auf Root-Ebene. Ohne die Zeile steht der Font **nicht** im `ngsw.json`, wird also bei jedem Besuch neu geladen und fehlt offline komplett. Nachgemessen:

```
vorher:  Font im SW-Manifest: NICHTS
nachher: Font im SW-Manifest: /kickbase/media/bootstrap-icons-CVBWLLHT.woff2
```

**4. `text-nowrap` am „Doku"-Button.** Kleine Regression, die erst durch diesen PR entsteht: das `<i>` war vorher 0 px breit, jetzt nimmt es echten Platz ein. Bei 375 px ist das Label dadurch in eine zweite Zeile gerutscht. Eine Klasse, Problem weg.

## Was das kostet

| | vorher | nachher | Δ |
|---|---|---|---|
| `styles.css` (gzip) | 25,42 kB | 35,69 kB | **+10,27 kB** |
| Initial total (gzip) | 155,46 kB | 165,72 kB | +10,26 kB |
| Icon-Font | – | 134 kB woff2 | lazy, dann SW-gecacht |

Ehrlich gesagt: für 18 Icons ist das viel. Ein CSS-Subset ginge leider nicht sauber – `$bootstrap-icons-map` ist im Paket **nicht** als `!default` deklariert, lässt sich also nicht per `with()` überschreiben. Ich müsste die Codepoints von Hand abschreiben, was beim nächsten Paket-Update still kaputtgehen kann. Und der Font (134 kB) bliebe ohnehin, er dominiert die Kosten.

Wenn dir das zu schwer ist, wäre die schlanke Alternative: die 18 SVGs aus `bootstrap-icons/icons/` nach `src/assets/` kopieren und auf `<svg-icon>` umstellen – also das Muster, das die anderen Icons im Projekt schon nutzen. Das wären ~8 kB statt 144 kB, aber 21 Template-Änderungen, Handarbeit bei den `fs-*`-Größen, und neue Icons müsstest du künftig einzeln herunterladen. Sag Bescheid, dann baue ich das um.

## Geprüft

- `npm run format:check` ✅
- `npm run test:ci` – **204/204** grün
- `npm run build:prod` ✅
- Manuell mit Mock-Daten durch, in **Hell und Dunkel**, bei **375 px und Desktop**: Rechner, Markt, „keine Liga ausgewählt", Login, aufgeklappte Hilfe, Update-Banner. Programmatisch gegengeprüft, dass alle Icons tatsächlich eine Breite > 0 haben, dass kein Container überläuft und dass die Seite nirgends horizontal scrollt. Keine Konsolenfehler.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
