### PR TITLE
fix: Sortierung "MW Änderung" zeigte in die falsche Richtung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Alle wichtigen Änderungen und Updates des Kickbase Calculators auf einen Blick.
 ### 🚀 Neue Features & Verbesserungen
 - **Dunkelmodus:** Der Rechner lässt sich jetzt zwischen Hell, Dunkel und der System-Einstellung des Geräts umschalten. Der Schalter sitzt oben rechts und ist auch auf der Login-Seite erreichbar. Die Auswahl wird im Browser gespeichert.
 
+### 🐛 Bugfixes & Wartung
+- **Sortierung "MW Änderung" korrigiert:** Die beiden Richtungen waren vertauscht – bei "MW Änderung ↓" stand die niedrigste Änderung oben statt der höchsten. Spieler ohne geladene Details stehen jetzt außerdem immer am Ende der Liste.
+
 ---
 
 ## [6.7.0] - 27.08.2026

--- a/doc/header.md
+++ b/doc/header.md
@@ -34,7 +34,7 @@ Beim Aktivieren dieser Option wird die Summe die ihr weiter oben bei [Erwartete 
 Beim Aktivieren dieser Option werden auch dei negativen Marktwerte in die Berechnung der Gewinne/Verluste bis Freitag mit einbezogen. Normalerweise holt man sich am Mittwoch ein Angebot und sichert sich so den Marktwert. Deswegen kann diese Option nur bei Bedarf aktiviert werden. siehe [Marktwertänderungen](#marketChanges)
 
 ### Sortierung
-Hier kann man die Sortierung der List der Spieler einstellen. Sie Sortierung MW Änderung greift erst nachdem alle [Details](#details) geladen wurden.
+Hier kann man die Sortierung der List der Spieler einstellen. Sie Sortierung MW Änderung greift erst nachdem alle [Details](#details) geladen wurden. Bei "MW Änderung &darr;" steht die höchste Änderung oben, bei "&uarr;" die niedrigste. Spieler ohne geladene Details stehen immer am Ende.
 
 ### Einnahmen Anzahl Tage ( Tag X)
 Hier kann man die Anzahl an Tage einstellen die für den voraussichtlichen [Marktwert Gewinn/Verlust](#marketChanges) verwendet werden soll. Beim Neuladen der Seite wird die Zahl immer auf den jeweils nächsten Freitag gelegt. Man kann diese Zahl hier aber nach Belieben ändern. Sollte der Spieltag z.B. auf einen Samstag fallen.

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -179,12 +179,12 @@
               [(ngModel)]="selectedSorting"
               (ngModelChange)="onSelectedSortingChanged($event)"
             >
-              <option [ngValue]="-1">Standard</option>
-              <option [ngValue]="1">MW &darr;</option>
-              <option [ngValue]="2">MW &uarr;</option>
-              <option [ngValue]="3">MW Änderung &darr;</option>
-              <option [ngValue]="4">MW Änderung &uarr;</option>
-              <option [ngValue]="5">Position (TW &rarr; ST)</option>
+              <option [ngValue]="sorting_default">Standard</option>
+              <option [ngValue]="sorting_mw_desc">MW &darr;</option>
+              <option [ngValue]="sorting_mw_asc">MW &uarr;</option>
+              <option [ngValue]="sorting_mw_change_desc">MW Änderung &darr;</option>
+              <option [ngValue]="sorting_mw_change_asc">MW Änderung &uarr;</option>
+              <option [ngValue]="sorting_position">Position (TW &rarr; ST)</option>
             </select>
           </div>
         </div>
@@ -326,12 +326,12 @@
             [(ngModel)]="selectedSorting"
             (ngModelChange)="onSelectedSortingChanged($event)"
           >
-            <option [ngValue]="-1">Standard</option>
-            <option [ngValue]="1">MW &darr;</option>
-            <option [ngValue]="2">MW &uarr;</option>
-            <option [ngValue]="3">MW Änderung &darr;</option>
-            <option [ngValue]="4">MW Änderung &uarr;</option>
-            <option [ngValue]="5">Position (TW &rarr; ST)</option>
+            <option [ngValue]="sorting_default">Standard</option>
+            <option [ngValue]="sorting_mw_desc">MW &darr;</option>
+            <option [ngValue]="sorting_mw_asc">MW &uarr;</option>
+            <option [ngValue]="sorting_mw_change_desc">MW Änderung &darr;</option>
+            <option [ngValue]="sorting_mw_change_asc">MW Änderung &uarr;</option>
+            <option [ngValue]="sorting_position">Position (TW &rarr; ST)</option>
           </select>
 
           <label class="form-label fw-semibold mb-1"

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -424,6 +424,59 @@ describe('AppComponent', () => {
       expect(component.kickbaseGroup.players[1].id).toBe(1);
     });
 
+    it('sollte Spieler nach Marktwertveränderung absteigend sortieren', () => {
+      component.selectedSorting = component.sorting_mw_change_desc;
+      component.sortCurrentPlayers();
+
+      expect(component.kickbaseGroup.players[0].id).toBe(1);
+      expect(component.kickbaseGroup.players[1].id).toBe(2);
+    });
+
+    // Die Auswahlliste in app.component.html bindet diese Zahlen. Sie landen auch im
+    // localStorage, deshalb pruefen die beiden Tests bewusst die Werte und nicht die
+    // Konstanten - genau hier lag der vertauschte Fall aus Issue #15.
+    it('sollte "MW Änderung ↓" (Wert 3) mit dem groessten Anstieg oben sortieren', () => {
+      component.selectedSorting = 3;
+      component.sortCurrentPlayers();
+
+      expect(component.kickbaseGroup.players[0].id).toBe(1);
+      expect(component.kickbaseGroup.players[1].id).toBe(2);
+    });
+
+    it('sollte "MW Änderung ↑" (Wert 4) mit dem groessten Verlust oben sortieren', () => {
+      component.selectedSorting = 4;
+      component.sortCurrentPlayers();
+
+      expect(component.kickbaseGroup.players[0].id).toBe(2);
+      expect(component.kickbaseGroup.players[1].id).toBe(1);
+    });
+
+    it('sollte "MW ↓" (Wert 1) und "MW ↑" (Wert 2) unveraendert lassen', () => {
+      component.selectedSorting = 1;
+      component.sortCurrentPlayers();
+      expect(component.kickbaseGroup.players[0].id).toBe(1);
+
+      component.selectedSorting = 2;
+      component.sortCurrentPlayers();
+      expect(component.kickbaseGroup.players[0].id).toBe(2);
+    });
+
+    it('sollte Spieler ohne geladene Details ans Ende sortieren', () => {
+      const pOhneStats = makePlayer(3, 'Ohne Details', 7000000);
+      pOhneStats.stats = null;
+      component.kickbaseGroup.players = [pOhneStats, p2, p1];
+
+      component.selectedSorting = component.sorting_mw_change_desc;
+      component.sortCurrentPlayers();
+
+      expect(component.kickbaseGroup.players.map((p) => p.id)).toEqual([1, 2, 3]);
+
+      component.selectedSorting = component.sorting_mw_change_asc;
+      component.sortCurrentPlayers();
+
+      expect(component.kickbaseGroup.players.map((p) => p.id)).toEqual([2, 1, 3]);
+    });
+
     it('sollte Speichern der Sortierung im localStorage ausführen', () => {
       component.onSelectedSortingChanged(component.sorting_mw_desc);
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -83,8 +83,8 @@ export class AppComponent implements OnInit, AfterViewInit {
   public readonly sorting_default = -1;
   public readonly sorting_mw_desc = 1;
   public readonly sorting_mw_asc = 2;
-  public readonly sorting_mw_change_asc = 3;
-  public readonly sorting_mw_change_desc = 4;
+  public readonly sorting_mw_change_desc = 3;
+  public readonly sorting_mw_change_asc = 4;
   public readonly sorting_position = 5;
 
   public selectedSorting: number = -1;
@@ -583,8 +583,14 @@ export class AppComponent implements OnInit, AfterViewInit {
         const aChange = a.stats?.realMarketValueChange;
         const bChange = b.stats?.realMarketValueChange;
 
+        // Ohne geladene Details ist die Aenderung unbekannt. Diese Spieler landen
+        // immer am Ende, statt an ihrer zufaelligen Ausgangsposition zu bleiben.
         if (aChange === undefined || bChange === undefined) {
-          return 0;
+          if (aChange === bChange) {
+            return 0;
+          }
+
+          return aChange === undefined ? 1 : -1;
         }
 
         if (aChange === bChange) {

--- a/src/app/model/kickbase-player.spec.ts
+++ b/src/app/model/kickbase-player.spec.ts
@@ -140,13 +140,22 @@ describe('KickbasePlayer', () => {
     });
 
     it('setzt expiryColor rot bei <= 1 Stunde und gruen bei <= 2 Stunden', () => {
-      player.expiry = 1800;
-      player.calcColors(0);
-      expect(player.expiryColor).toBe(KickbaseGroup.color_red);
+      // isUntilMarketValueUpdate vergleicht gegen 22:00 Uhr des laufenden Tages. Ohne feste
+      // Uhrzeit faellt der zweite Fall ab 20:30 Uhr durch - der Test war also zeitabhaengig.
+      jasmine.clock().install();
+      jasmine.clock().mockDate(new Date(2026, 0, 15, 12, 0, 0));
 
-      player.expiry = 5400;
-      player.calcColors(0);
-      expect(player.expiryColor).toBe(KickbaseGroup.color_yellow);
+      try {
+        player.expiry = 1800;
+        player.calcColors(0);
+        expect(player.expiryColor).toBe(KickbaseGroup.color_red);
+
+        player.expiry = 5400;
+        player.calcColors(0);
+        expect(player.expiryColor).toBe(KickbaseGroup.color_yellow);
+      } finally {
+        jasmine.clock().uninstall();
+      }
     });
   });
 


### PR DESCRIPTION
Closes #15

## Das Problem

Die Auswahlliste trägt feste Zahlen, und im Code hängt an jeder Zahl eine Konstante. Bei "MW Änderung" waren `asc` und `desc` schlicht auf den falschen Zahlen:

| Auswahl | Wert | zeigte auf | Ergebnis |
|---|---|---|---|
| MW &darr; | 1 | `sorting_mw_desc` | höchster oben ✅ |
| MW &uarr; | 2 | `sorting_mw_asc` | niedrigster oben ✅ |
| MW Änderung &darr; | 3 | `sorting_mw_change_asc` | **niedrigste Änderung oben** ❌ |
| MW Änderung &uarr; | 4 | `sorting_mw_change_desc` | **höchste Änderung oben** ❌ |

Deswegen ist es Daxelinho auch genau so aufgefallen: eine Sortierung stimmt, die direkt darunter nicht.

Nachgemessen mit sechs Testspielern, Auswahl "MW Änderung &darr;":

```
vorher:  -400.000 → -50.000 → 0 → +150.000 → +250.000 → +900.000
nachher: +900.000 → +250.000 → +150.000 → 0 → -50.000 → -400.000
```

## Änderungen

**1. Konstanten getauscht.** `sorting_mw_change_desc` ist jetzt 3, `sorting_mw_change_asc` ist 4. Die Zahlen selbst habe ich bewusst gelassen, weil sie im `localStorage` liegen – wer "MW Änderung &darr;" ausgewählt hatte, bekommt jetzt einfach das, was auf dem Label steht. Kein Umzug nötig.

**2. Die Auswahlliste bindet die Konstanten namentlich.** Statt `[ngValue]="3"` jetzt `[ngValue]="sorting_mw_change_desc"`, in beiden Ansichten. Damit können Label und Richtung nicht wieder auseinanderlaufen, und man sieht beim Lesen des Templates sofort, was gemeint ist. Deine `selectedSorting === sorting_position`-Vergleiche weiter unten machen das ja schon genauso.

**3. Spieler ohne geladene Details landen am Ende.** Der Vergleich gab für sie bisher immer `0` zurück. Das ist kein gültiger Comparator (nicht transitiv) – die standen dann verstreut zwischen den sortierten Spielern. Jetzt rutschen sie ans Ende, in beide Richtungen. Betrifft nur Leute, die "Alle Details automatisch laden" ausgeschaltet haben. Sag Bescheid, wenn du das lieber getrennt hättest, dann nehme ich es raus.

## Eine Entscheidung, die eigentlich dir gehört

Es gibt zwei vertretbare Lesarten von "&darr;":

- **"absteigend"** = größter Wert oben → dann war der Code falsch, so wie ich es hier gefixt habe
- **"fallend"** = größter Verlust oben → dann wäre der Code richtig gewesen und nur die **Labels** vertauscht

Ich habe mich für die erste entschieden, weil sie zu "MW &darr;" passt und der Melder es genau so begründet hat. Falls du es andersherum siehst, ist es ein Zweizeiler in der Auswahlliste – sag einfach Bescheid.

## Noch ein Commit obendrauf: ein zeitabhängiger Test

Beim Aufsetzen ist mir aufgefallen, dass `kickbase-player.spec.ts` auf `main` durchfällt, sobald es nach 20:30 Uhr ist. Der Test prüft für `expiry = 5400` (1,5 Stunden) die gelbe Einfärbung, und `isUntilMarketValueUpdate` vergleicht dafür gegen 22:00 Uhr des laufenden Tages. Abends liegt der Ablauf also am Folgetag und die Erwartung stimmt nicht mehr.

Die Action läuft in UTC – die Pipeline war damit jeden Abend zwischen 20:30 und 24:00 UTC rot, ohne dass sich am Code etwas geändert hätte. `jasmine.clock()` setzt jetzt eine feste Uhrzeit.

Derselbe Commit steckt auch in dem PR für #4, damit beide unabhängig voneinander grün durchlaufen. Git löst das beim Mergen von selbst auf, weil die Änderung identisch ist.

## Geprüft

- `npm run format:check` ✅
- `npm run test:ci` – **209/209** grün (204 vorher + 5 neue: beide Richtungen einzeln, die Zahlen 1–4 aus der Auswahlliste, und Spieler ohne Details)
- `npm run build:prod` ✅ – unverändert
- Manuell mit Testdaten alle sechs Sortierungen durch, in **Rechner und Marktübersicht**, hell und dunkel. Zusätzlich einmal mit und einmal ohne diesen Fix gemessen, um die Reihenfolge oben direkt gegenüberzustellen. Keine Konsolenfehler.

## Kleiner Hinweis zum Mergen

`CHANGELOG.md` und `doc/header.md` fasse ich hier an denselben Stellen an wie in #25 und im PR zu #4. Falls es beim zweiten oder dritten Merge zickt, ist es jeweils eine Zeile.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
